### PR TITLE
Hotfix scoring baseline updates 2

### DIFF
--- a/R/baseline_annotator.R
+++ b/R/baseline_annotator.R
@@ -538,7 +538,7 @@ get_matched_pvs <- function(ov, pv_df, verbose = TRUE) {
 
 
 # Extract and format value domain (VD) information for the current result.
-ollect_result_vd <- function(
+collect_result_vd <- function(
   cadsr_df,
   de_id,
   ov,

--- a/R/scoring.R
+++ b/R/scoring.R
@@ -61,7 +61,7 @@ get_de_id <- function(res_data) {
 }
 
 get_dec_id <- function(res_data) {
-  
+
   suppressWarnings(
     if (res_data$result$dataElementConcept$name == "NOMATCH") {
       ""
@@ -73,7 +73,7 @@ get_dec_id <- function(res_data) {
 }
 
 get_dec_concepts <- function(res_data) {
-  
+  print(res_data$result$dataElementConcept$name)
   suppressWarnings(
     if (res_data$result$dataElementConcept$name == "NOMATCH") {
       c()
@@ -88,7 +88,7 @@ get_dec_concepts <- function(res_data) {
 get_value_domain <- function(res_data) {
   
 
-    if (res_data$result$dataElement$name == "NOMATCH") {
+    if (res_data$result$dataElement$name == "NOMATCH" || length(res_data$result$valueDomain) == 0) {
       tibble::tibble(observedValue = NA, name = NA, id = NA) %>% 
         dplyr::filter(complete.cases(.))
     } else {

--- a/R/scoring.R
+++ b/R/scoring.R
@@ -73,7 +73,6 @@ get_dec_id <- function(res_data) {
 }
 
 get_dec_concepts <- function(res_data) {
-  print(res_data$result$dataElementConcept$name)
   suppressWarnings(
     if (res_data$result$dataElementConcept$name == "NOMATCH") {
       c()


### PR DESCRIPTION
The scoring script currently thrown an error when a field has a `valueDomain` set to an empty array in the JSON file of a submission file or gold standard file.

This PR investigate a fix for this issue (WIP).