### PR TITLE
value coverage scoring fix

### DIFF
--- a/R/scoring.R
+++ b/R/scoring.R
@@ -97,7 +97,8 @@ get_value_domain <- function(res_data) {
                           conceptCode = .$permissibleValue$conceptCode)) %>% 
         purrr::modify_depth(2, ~ ifelse(is.null(.), "", .)) %>%
         purrr::map_df(tibble::as_tibble) %>%
-        dplyr::mutate(conceptCode = ifelse(conceptCode == "", NA, conceptCode))
+        dplyr::mutate(conceptCode = ifelse(conceptCode == "", NA, conceptCode)) %>%
+        dplyr::distinct()
     }
 
 }
@@ -136,15 +137,22 @@ score_value_coverage <- function(sub_res_data, anno_res_data) {
   }
   mismatch_rows <- find_mismatch_rows(sub_vd, anno_vd, check_col)
   if (nrow(anno_vd)) {
-    if (length(mismatch_rows)) {
-      1 - (length(mismatch_rows) / nrow(anno_vd))
+    if (nrow(sub_vd)) {
+      if (length(mismatch_rows)) {
+        1 - (length(mismatch_rows) / nrow(sub_vd))
+      } else {
+        1
+      }
     } else {
-      1
+      0
     }
   } else {
-    0
+    if (!nrow(sub_vd)) {
+      1
+    } else {
+      1 - (length(mismatch_rows) / nrow(sub_vd))
+    }
   }
-  
 }
 
 


### PR DESCRIPTION
In addition to adding the fix @jaeddy suggested, I also included a step to only keep the unique value domains for each column. I noticed that when a submission has duplicate correct vds, it  consequently increases the overall score, e.g.

### G2 appears once
**submission**
```
"valueDomain": [
    {
    "observedValue": "0.0",
    "permissibleValue": {
        "conceptCode": null,
        "value": "NOMATCH"
    }
    },
    {
    "observedValue": "G2",
    "permissibleValue": {
        "value": "Moderately Differentiated",
        "conceptCode": "ncit:C14162"
    }
    },              
    {
    "observedValue": "g3",
    "permissibleValue": {
        "conceptCode": null,
        "value": "NOMATCH"
    }
    }
]
```

**results**
```
> score_submission("test-Submission.json", "Annotated-ROI-Masks.json")
4.66666666666667
```

### G2 appears twice
**submission**
```
"valueDomain": [
    {
    "observedValue": "0.0",
    "permissibleValue": {
        "conceptCode": null,
        "value": "NOMATCH"
    }
    },
    {
    "observedValue": "G2",
    "permissibleValue": {
        "value": "Moderately Differentiated",
        "conceptCode": "ncit:C14162"
    }
    },              
    {
    "observedValue": "G2",
    "permissibleValue": {
        "value": "Moderately Differentiated",
        "conceptCode": "ncit:C14162"
    }
    },
    {
    "observedValue": "g3",
    "permissibleValue": {
        "conceptCode": null,
        "value": "NOMATCH"
    }
    }
]
```

**results**
```
> score_submission("test-Submission.json", "Annotated-ROI-Masks.json")
4.75
```