### PR TITLE
Score fixes

### DIFF
--- a/R/scoring.R
+++ b/R/scoring.R
@@ -105,8 +105,15 @@ get_value_domain <- function(res_data) {
 
 find_mismatch_rows <- function(df_a, df_b, col_name = "conceptCode") {
   # TODO: fix logic of this function
-  df_a[[col_name]][!(df_a[[col_name]] %in% df_b[[col_name]])]
+  #df_a[[col_name]][!(df_a[[col_name]] %in% df_b[[col_name]])]
   
+  # # grab the column of interest then find the difference
+  df_a <- df_a %>% select("observedValue", col_name)
+  df_a[[col_name]] <- replace_na(df_a[[col_name]], "")
+  df_b <- df_b %>% select("observedValue", col_name)
+  df_b[[col_name]] <- replace_na(df_b[[col_name]], "")
+
+  setdiff(df_a, df_b)[[col_name]]
 }
 
 
@@ -127,6 +134,8 @@ score_value_coverage <- function(sub_res_data, anno_res_data) {
   anno_nonenum <- any(stringr::str_detect(anno_vd$value, "CONFORMING"))
   if (!nrow(anno_vd) & !nrow(sub_vd)) {
     return(1)
+  } else if (nrow(anno_vd) & !nrow(sub_vd)) {
+    return(0)
   }
   
   if (anno_nonenum) {
@@ -135,23 +144,23 @@ score_value_coverage <- function(sub_res_data, anno_res_data) {
     check_col <- "conceptCode"
   }
   mismatch_rows <- find_mismatch_rows(sub_vd, anno_vd, check_col)
-  if (nrow(anno_vd)) {
-    if (nrow(sub_vd)) {
+  # if (nrow(anno_vd)) {
+  #   if (nrow(sub_vd)) {
       if (length(mismatch_rows)) {
         1 - (length(mismatch_rows) / nrow(sub_vd))
       } else {
         1
       }
-    } else {
-      0
-    }
-  } else {
-    if (!nrow(sub_vd)) {
-      1
-    } else {
-      1 - (length(mismatch_rows) / nrow(sub_vd))
-    }
-  }
+    # } else {
+    #   0
+    # }
+  # } else {
+  #   if (!nrow(sub_vd)) {
+  #     1
+  #   } else {
+  #     1 - (length(mismatch_rows) / nrow(sub_vd))
+  #   }
+  # }
 }
 
 

--- a/R/scoring.R
+++ b/R/scoring.R
@@ -85,22 +85,21 @@ get_dec_concepts <- function(res_data) {
 }
 
 get_value_domain <- function(res_data) {
-  
-
-    if (res_data$result$dataElement$name == "NOMATCH" || length(res_data$result$valueDomain) == 0) {
-      tibble::tibble(observedValue = NA, name = NA, id = NA) %>% 
-        dplyr::filter(complete.cases(.))
-    } else {
-      res_data$result$valueDomain %>% 
-        purrr::map(~ list(observedValue = .$observedValue, 
-                          value = .$permissibleValue$value, 
-                          conceptCode = .$permissibleValue$conceptCode)) %>% 
-        purrr::modify_depth(2, ~ ifelse(is.null(.), "", .)) %>%
-        purrr::map_df(tibble::as_tibble) %>%
-        dplyr::mutate(conceptCode = ifelse(conceptCode == "", NA, conceptCode)) %>%
-        dplyr::distinct()
-    }
-
+  if (length(res_data$result$valueDomain) == 0) {
+    tibble::tibble(observedValue = NA, name = NA, id = NA) %>%
+      dplyr::filter(complete.cases(.))
+  } else {
+    res_data$result$valueDomain %>%
+      purrr::map(~ list(
+        observedValue = .$observedValue,
+        value = .$permissibleValue$value,
+        conceptCode = .$permissibleValue$conceptCode
+      )) %>%
+      purrr::modify_depth(2, ~ ifelse(is.null(.), "", .)) %>%
+      purrr::map_df(tibble::as_tibble) %>%
+      dplyr::mutate(conceptCode = ifelse(conceptCode == "", NA, conceptCode)) %>%
+      dplyr::distinct()
+  }
 }
 
 

--- a/R/scoring.R
+++ b/R/scoring.R
@@ -107,7 +107,7 @@ find_mismatch_rows <- function(df_a, df_b, col_name = "conceptCode") {
   # TODO: fix logic of this function
   #df_a[[col_name]][!(df_a[[col_name]] %in% df_b[[col_name]])]
   
-  # # grab the column of interest then find the difference
+  # Grab the column of interest and replace NAs in the said column
   df_a <- df_a %>% select("observedValue", col_name)
   df_a[[col_name]] <- replace_na(df_a[[col_name]], "")
   df_b <- df_b %>% select("observedValue", col_name)
@@ -128,39 +128,30 @@ score_concept_overlap <- function(sub_res_data, anno_res_data) {
 
 
 score_value_coverage <- function(sub_res_data, anno_res_data) {
-
+  
   sub_vd <- get_value_domain(sub_res_data)
   anno_vd <- get_value_domain(anno_res_data)
   anno_nonenum <- any(stringr::str_detect(anno_vd$value, "CONFORMING"))
+  
+  # Return 1 if both value domains are empty, whereas return 0 if the
+  # goldstandard has >0 VD but the submission predicted none
   if (!nrow(anno_vd) & !nrow(sub_vd)) {
     return(1)
   } else if (nrow(anno_vd) & !nrow(sub_vd)) {
     return(0)
   }
-  
+
   if (anno_nonenum) {
     check_col <- "value"
   } else {
     check_col <- "conceptCode"
   }
   mismatch_rows <- find_mismatch_rows(sub_vd, anno_vd, check_col)
-  # if (nrow(anno_vd)) {
-  #   if (nrow(sub_vd)) {
-      if (length(mismatch_rows)) {
-        1 - (length(mismatch_rows) / nrow(sub_vd))
-      } else {
-        1
-      }
-    # } else {
-    #   0
-    # }
-  # } else {
-  #   if (!nrow(sub_vd)) {
-  #     1
-  #   } else {
-  #     1 - (length(mismatch_rows) / nrow(sub_vd))
-  #   }
-  # }
+  if (length(mismatch_rows)) {
+    1 - (length(mismatch_rows) / nrow(sub_vd))
+  } else {
+    1
+  }
 }
 
 


### PR DESCRIPTION
1. `get_value_domain()` - logic has been updated to return an empty tibble only when there are zero value domains; the DE name is no longer a factor

This fix is in response to this [discussion post](https://www.synapse.org/#!Synapse:syn18065891/discussion/threadId=6950&replyId=22197) (in addition to [this one](https://www.synapse.org/#!Synapse:syn18065891/discussion/threadId=6982)).


2. `find_mismatch_rows()` - the FIXME has been addressed (I think).  The function now also considers the corresponding observedValue (rather than just the col_check) when doing the row comparisons, e.g.

**submission**
```
  observedValue                                 conceptCode
  <chr>                                         <chr>      
1 Disease progression                           NA         
2 Both disease progression and cancer treatment NA         
3 Unknown                                       ncit:CABC 
```

**gold**
```
  observedValue                                 conceptCode
  <chr>                                         <chr>      
1 Disease progression                           ncit:C35571
2 Both disease progression and cancer treatment NA         
3 Unknown                                       NA 
```

This fix is in response to this [discussion post](https://www.synapse.org/#!Synapse:syn18065891/discussion/threadId=6965). <-- If my understanding is correct, the expected score should be 0.167 and not 0 (or 0.333), since that bogus submission technically got one out of 3 value domains correct. Lmk if this isn't right!

3. `score_value_coverage()` - cleaned up the conditionals so that it's not as nested and hard to read (also added comments!).

---

For a sanity check, I did test all the changes with a "perfect" submission as well, and got the expected 0.5 score back for VD coverage :)