### PR TITLE
adding one more conditional for value domain coverage

### DIFF
--- a/R/scoring.R
+++ b/R/scoring.R
@@ -139,6 +139,8 @@ score_value_coverage <- function(sub_res_data, anno_res_data) {
     return(1)
   } else if (nrow(anno_vd) & !nrow(sub_vd)) {
     return(0)
+  } else if (!nrow(anno_vd) & nrow(sub_vd)) {
+    return(0)
   }
 
   if (anno_nonenum) {


### PR DESCRIPTION
Added one more conditional to `score_value_coverage()` for the case when the goldstandard has zero value domains but the submission has >0